### PR TITLE
Rename CapacityValue to CapacityCredit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,9 @@ git:
 
 ## uncomment the following lines to override the default test script
 #script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("CapacityValue"); Pkg.test("CapacityValue"; coverage=true)'
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("CapacityCredit"); Pkg.test("CapacityCredit"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
-  - julia -e 'cd(Pkg.dir("CapacityValue")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'cd(Pkg.dir("CapacityCredit")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   # push coverage results to Codecov
-  - julia -e 'cd(Pkg.dir("CapacityValue")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'cd(Pkg.dir("CapacityCredit")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The CapacityValue.jl package is licensed under a modified MIT "Expat" License:
+The CapacityCredit.jl package is licensed under a modified MIT "Expat" License:
 
 > Copyright 2018 Alliance for Sustainable Energy, LLC
 >

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "CapacityValue"
+name = "CapacityCredit"
 uuid = "e9572c70-259d-42a9-812a-bf29f717e3f1"
 authors = ["Gord Stephen <gord.stephen@nrel.gov>"]
 version = "0.4.0"

--- a/README.md
+++ b/README.md
@@ -1,21 +1,22 @@
-# CapacityValue
+# CapacityCredit
 
 To assess the equivalent firm capacity a new resource added
 to the system in region 3:
 
 ```julia
-using ResourceAdequacy, CapacityValue, Distributions
-multiperiod_system_new_resource # The previous system augmented with a new resource
+using ResourceAdequacy, CapacityCredit, Distributions
+system # The base system
+system_new_resource # The base system augmented with a new variable resource
 assess(EFC(1000, 0.95, 1, DiscreteNonParametric([3], [1.0])),
-       LOLE, REPRA(1, 10), NonSequentialNetworkFlow(100_000), Minimal(),
-	   multiperiod_system, multiperiod_system_new_resource)
+       EUE, Backcast(), NonSequentialNetworkFlow(100_000), Minimal(),
+       system, system_new_resource)
 ```
 
 ## Capacity Valuation Components
 
 Capacity valuation requires specifying all of the components required for a single- or multi-period reliability assessment, as well as a reliability and capacity value metric to use:
 
-### Capacity Value Metric
+### Capacity Credit Metric
 
 Currently supported:
  - EFC

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,7 +41,7 @@ build_script:
 # Need to convert from shallow to complete for Pkg.clone to work
   - IF EXIST .git\shallow (git fetch --unshallow)
   - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"CapacityValue\"); Pkg.build(\"CapacityValue\")"
+      Pkg.clone(pwd(), \"CapacityCredit\"); Pkg.build(\"CapacityCredit\")"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"CapacityValue\")"
+  - C:\projects\julia\bin\julia -e "Pkg.test(\"CapacityCredit\")"

--- a/src/CapacityCredit.jl
+++ b/src/CapacityCredit.jl
@@ -1,4 +1,4 @@
-module CapacityValue
+module CapacityCredit
 
 using Distributions
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using CapacityValue
+using CapacityCredit
 @static if VERSION < v"0.7.0-DEV.2005"
     using Base.Test
 else


### PR DESCRIPTION
Change the package name in light of our decision to reserve the term "value" for economic analysis. Closes #1 